### PR TITLE
prevent error highlighting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ It follows the current color theme out-of-the-box, as soon as the theme
 enables semantic colorization through its `semanticHighlighting` setting.
 You can forcefully enable semantic highlighting in `settings.json`:
 
-```json
+```jsonc
 "editor.semanticTokenColorCustomizations": {
     "enabled": true, // enable for all themes
     "[Default Dark+]": {


### PR DESCRIPTION
Currently, the comments in the JSON example are highlighted as errors.

<img width="1028" alt="image" src="https://github.com/fallenwood/syntax-highlighter/assets/1504938/2c07307d-7f7a-440d-ae19-e70c62a8bd00">

This PR changes the syntax to JSONC (JSON with Comments), hence allowing comments and suppressing the highlighted text.
